### PR TITLE
Bump Kotlin version from 1.6.10 to 1.6.21 (final)

### DIFF
--- a/AddShoppingListElement.http
+++ b/AddShoppingListElement.http
@@ -1,0 +1,7 @@
+POST http://localhost:9090/shoppingList
+Content-Type: application/json
+
+{
+  "desc": "Peppers 🌶",
+  "priority": 5
+}

--- a/DeleteShoppingListElement.http
+++ b/DeleteShoppingListElement.http
@@ -1,0 +1,1 @@
+DELETE http://localhost:9090/shoppingList/AN_ID_GOES_HERE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ val reactVersion = "17.0.2-pre.299-kotlin-1.6.10"
 val kmongoVersion = "4.5.0"
 
 plugins {
-    kotlin("multiplatform") version "1.6.10"
+    kotlin("multiplatform") version "1.6.21"
     application //to run JVM part
     kotlin("plugin.serialization") version "1.6.10"
 }

--- a/src/commonMain/kotlin/ShoppingListItem.kt
+++ b/src/commonMain/kotlin/ShoppingListItem.kt
@@ -1,0 +1,10 @@
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ShoppingListItem(val desc: String, val priority: Int) {
+    val id: Int = desc.hashCode()
+
+    companion object {
+        const val path = "/shoppingList"
+    }
+}

--- a/src/jsMain/kotlin/Api.kt
+++ b/src/jsMain/kotlin/Api.kt
@@ -1,0 +1,28 @@
+import io.ktor.http.*
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+
+import kotlin.browser.window
+
+val endpoint = window.location.origin // only needed until https://github.com/ktorio/ktor/issues/1695 is resolved
+
+val jsonClient = HttpClient {
+    install(JsonFeature) { serializer = KotlinxSerializer() }
+}
+
+suspend fun getShoppingList(): List<ShoppingListItem> {
+    return jsonClient.get(endpoint + ShoppingListItem.path)
+}
+
+suspend fun addShoppingListItem(shoppingListItem: ShoppingListItem) {
+    jsonClient.post<Unit>(endpoint + ShoppingListItem.path) {
+        contentType(ContentType.Application.Json)
+        body = shoppingListItem
+    }
+}
+
+suspend fun deleteShoppingListItem(shoppingListItem: ShoppingListItem) {
+    jsonClient.delete<Unit>(endpoint + ShoppingListItem.path + "/${shoppingListItem.id}")
+}

--- a/src/jsMain/kotlin/Api.kt
+++ b/src/jsMain/kotlin/Api.kt
@@ -4,7 +4,7 @@ import io.ktor.client.request.*
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
 
-import kotlin.browser.window
+import kotlinx.browser.window
 
 val endpoint = window.location.origin // only needed until https://github.com/ktorio/ktor/issues/1695 is resolved
 

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -4,7 +4,7 @@ import kotlinext.js.*
 import kotlinx.html.js.*
 import kotlinx.coroutines.*
 
-val scope = MainScope()
+private val scope = MainScope()
 
 val App = functionalComponent<RProps> { _ ->
     val (shoppingList, setShoppingList) = useState(emptyList<ShoppingListItem>())

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -1,0 +1,47 @@
+import react.*
+import react.dom.*
+import kotlinext.js.*
+import kotlinx.html.js.*
+import kotlinx.coroutines.*
+
+val scope = MainScope()
+
+val App = functionalComponent<RProps> { _ ->
+    val (shoppingList, setShoppingList) = useState(emptyList<ShoppingListItem>())
+
+    useEffect(dependencies = listOf()) {
+        scope.launch {
+            setShoppingList(getShoppingList())
+        }
+    }
+
+    h1 {
+        +"Full-Stack Shopping List"
+    }
+    ul {
+        shoppingList.sortedByDescending(ShoppingListItem::priority).forEach { item ->
+            li {
+                key = item.toString()
+                attrs.onClickFunction = {
+                    scope.launch {
+                        deleteShoppingListItem(item)
+                        setShoppingList(getShoppingList())
+                    }
+                }
+                +"[${item.priority}] ${item.desc} "
+            }
+        }
+    }
+    child(
+        functionalComponent = InputComponent,
+        props = jsObject {
+            onSubmit = { input ->
+                val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' })
+                scope.launch {
+                    addShoppingListItem(cartItem)
+                    setShoppingList(getShoppingList())
+                }
+            }
+        }
+    )
+}

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -6,11 +6,11 @@ import kotlinx.coroutines.*
 private val scope = MainScope()
 
 val app = fc<Props> {
-    val (shoppingList, setShoppingList) = useState(emptyList<ShoppingListItem>())
+    var shoppingList by useState(emptyList<ShoppingListItem>())
 
     useEffectOnce {
         scope.launch {
-            setShoppingList(getShoppingList())
+            shoppingList = getShoppingList()
         }
     }
 
@@ -24,7 +24,7 @@ val app = fc<Props> {
                 attrs.onClickFunction = {
                     scope.launch {
                         deleteShoppingListItem(item)
-                        setShoppingList(getShoppingList())
+                        shoppingList = getShoppingList()
                     }
                 }
                 +"[${item.priority}] ${item.desc} "
@@ -36,7 +36,7 @@ val app = fc<Props> {
             val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' })
             scope.launch {
                 addShoppingListItem(cartItem)
-                setShoppingList(getShoppingList())
+                shoppingList = getShoppingList()
             }
         }
     }

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.*
 
 private val scope = MainScope()
 
-val App = fc<Props> {
+val app = fc<Props> {
     val (shoppingList, setShoppingList) = useState(emptyList<ShoppingListItem>())
 
     useEffectOnce {

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -31,7 +31,7 @@ val app = fc<Props> {
             }
         }
     }
-    child(InputComponent) {
+    child(inputComponent) {
         attrs.onSubmit = { input ->
             val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' })
             scope.launch {

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -1,15 +1,14 @@
 import react.*
 import react.dom.*
-import kotlinext.js.*
 import kotlinx.html.js.*
 import kotlinx.coroutines.*
 
 private val scope = MainScope()
 
-val App = functionalComponent<RProps> { _ ->
+val App = fc<Props> {
     val (shoppingList, setShoppingList) = useState(emptyList<ShoppingListItem>())
 
-    useEffect {
+    useEffectOnce {
         scope.launch {
             setShoppingList(getShoppingList())
         }
@@ -32,16 +31,13 @@ val App = functionalComponent<RProps> { _ ->
             }
         }
     }
-    child(
-        InputComponent,
-        props = jsObject {
-            onSubmit = { input ->
-                val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' })
-                scope.launch {
-                    addShoppingListItem(cartItem)
-                    setShoppingList(getShoppingList())
-                }
+    child(InputComponent) {
+        attrs.onSubmit = { input ->
+            val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' })
+            scope.launch {
+                addShoppingListItem(cartItem)
+                setShoppingList(getShoppingList())
             }
         }
-    )
+    }
 }

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -9,7 +9,7 @@ private val scope = MainScope()
 val App = functionalComponent<RProps> { _ ->
     val (shoppingList, setShoppingList) = useState(emptyList<ShoppingListItem>())
 
-    useEffect(dependencies = listOf()) {
+    useEffect {
         scope.launch {
             setShoppingList(getShoppingList())
         }

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -33,7 +33,7 @@ val App = functionalComponent<RProps> { _ ->
         }
     }
     child(
-        functionalComponent = InputComponent,
+        InputComponent,
         props = jsObject {
             onSubmit = { input ->
                 val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' })

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -1,11 +1,12 @@
 import react.*
-import react.dom.*
-import kotlinx.html.js.*
 import kotlinx.coroutines.*
+import react.dom.html.ReactHTML.h1
+import react.dom.html.ReactHTML.li
+import react.dom.html.ReactHTML.ul
 
 private val scope = MainScope()
 
-val app = fc<Props> {
+val App = FC<Props> {
     var shoppingList by useState(emptyList<ShoppingListItem>())
 
     useEffectOnce {
@@ -21,7 +22,7 @@ val app = fc<Props> {
         shoppingList.sortedByDescending(ShoppingListItem::priority).forEach { item ->
             li {
                 key = item.toString()
-                attrs.onClickFunction = {
+                onClick = {
                     scope.launch {
                         deleteShoppingListItem(item)
                         shoppingList = getShoppingList()
@@ -31,8 +32,8 @@ val app = fc<Props> {
             }
         }
     }
-    child(inputComponent) {
-        attrs.onSubmit = { input ->
+    InputComponent {
+        onSubmit = { input ->
             val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' })
             scope.launch {
                 addShoppingListItem(cartItem)

--- a/src/jsMain/kotlin/InputComponent.kt
+++ b/src/jsMain/kotlin/InputComponent.kt
@@ -1,0 +1,33 @@
+import react.*
+import react.dom.*
+import kotlinx.html.js.*
+import kotlinx.html.InputType
+import org.w3c.dom.events.Event
+import org.w3c.dom.HTMLInputElement
+
+external interface InputProps : RProps {
+    var onSubmit: (String) -> Unit
+}
+
+val InputComponent = functionalComponent<InputProps> { props ->
+    val (text, setText) = useState("")
+
+    val submitHandler: (Event) -> Unit = {
+        it.preventDefault()
+        setText("")
+        props.onSubmit(text)
+    }
+
+    val changeHandler: (Event) -> Unit = {
+        val value = (it.target as HTMLInputElement).value
+        setText(value)
+    }
+
+    form {
+        attrs.onSubmitFunction = submitHandler
+        input(InputType.text) {
+            attrs.onChangeFunction = changeHandler
+            attrs.value = text
+        }
+    }
+}

--- a/src/jsMain/kotlin/InputComponent.kt
+++ b/src/jsMain/kotlin/InputComponent.kt
@@ -9,7 +9,7 @@ external interface InputProps : Props {
     var onSubmit: (String) -> Unit
 }
 
-val InputComponent = fc<InputProps> { props ->
+val inputComponent = fc<InputProps> { props ->
     val (text, setText) = useState("")
 
     val submitHandler: (Event) -> Unit = {

--- a/src/jsMain/kotlin/InputComponent.kt
+++ b/src/jsMain/kotlin/InputComponent.kt
@@ -5,11 +5,11 @@ import kotlinx.html.InputType
 import org.w3c.dom.events.Event
 import org.w3c.dom.HTMLInputElement
 
-external interface InputProps : RProps {
+external interface InputProps : Props {
     var onSubmit: (String) -> Unit
 }
 
-val InputComponent = functionalComponent<InputProps> { props ->
+val InputComponent = fc<InputProps> { props ->
     val (text, setText) = useState("")
 
     val submitHandler: (Event) -> Unit = {

--- a/src/jsMain/kotlin/InputComponent.kt
+++ b/src/jsMain/kotlin/InputComponent.kt
@@ -1,33 +1,35 @@
+import org.w3c.dom.HTMLFormElement
 import react.*
-import react.dom.*
-import kotlinx.html.js.*
-import kotlinx.html.InputType
-import org.w3c.dom.events.Event
 import org.w3c.dom.HTMLInputElement
+import react.dom.events.ChangeEventHandler
+import react.dom.events.FormEventHandler
+import react.dom.html.InputType
+import react.dom.html.ReactHTML.form
+import react.dom.html.ReactHTML.input
 
 external interface InputProps : Props {
     var onSubmit: (String) -> Unit
 }
 
-val inputComponent = fc<InputProps> { props ->
+val InputComponent = FC<InputProps> { props ->
     val (text, setText) = useState("")
 
-    val submitHandler: (Event) -> Unit = {
+    val submitHandler: FormEventHandler<HTMLFormElement> = {
         it.preventDefault()
         setText("")
         props.onSubmit(text)
     }
 
-    val changeHandler: (Event) -> Unit = {
-        val value = (it.target as HTMLInputElement).value
-        setText(value)
+    val changeHandler: ChangeEventHandler<HTMLInputElement> = {
+        setText(it.target.value)
     }
 
     form {
-        attrs.onSubmitFunction = submitHandler
-        input(InputType.text) {
-            attrs.onChangeFunction = changeHandler
-            attrs.value = text
+        onSubmit = submitHandler
+        input {
+            type = InputType.text
+            onChange = changeHandler
+            value = text
         }
     }
 }

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -4,6 +4,6 @@ import kotlinx.browser.document
 
 fun main() {
     render(document.getElementById("root")) {
-        child(functionalComponent = App)
+        child(App)
     }
 }

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -1,9 +1,8 @@
-import react.child
 import react.dom.render
 import kotlinx.browser.document
 
 fun main() {
     render(document.getElementById("root")) {
-        child(App)
+        child(app)
     }
 }

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -1,5 +1,9 @@
+import react.child
+import react.dom.render
 import kotlinx.browser.document
 
 fun main() {
-    document.getElementById("root")?.innerHTML = "Hello, Kotlin/JS!"
+    render(document.getElementById("root")) {
+        child(functionalComponent = App)
+    }
 }

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -1,8 +1,8 @@
 import react.dom.render
 import kotlinx.browser.document
+import react.create
 
 fun main() {
-    render(document.getElementById("root")) {
-        child(app)
-    }
+    val container = document.getElementById("root") ?: error("Couldn't find container!")
+    render(App.create(), container)
 }

--- a/src/jvmMain/kotlin/Server.kt
+++ b/src/jvmMain/kotlin/Server.kt
@@ -9,16 +9,15 @@ import io.ktor.serialization.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import org.litote.kmongo.*
-import org.litote.kmongo.async.*
 import org.litote.kmongo.coroutine.*
-import org.litote.kmongo.async.getCollection
 import com.mongodb.ConnectionString
+import org.litote.kmongo.reactivestreams.KMongo
 
 val connectionString: ConnectionString? = System.getenv("MONGODB_URI")?.let {
     ConnectionString("$it?retryWrites=false")
 }
 
-val client = if (connectionString != null) KMongo.createClient(connectionString) else KMongo.createClient()
+val client = if (connectionString != null) KMongo.createClient(connectionString).coroutine else KMongo.createClient().coroutine
 val database = client.getDatabase(connectionString?.database ?: "test")
 val collection = database.getCollection<ShoppingListItem>()
 

--- a/src/jvmMain/kotlin/Server.kt
+++ b/src/jvmMain/kotlin/Server.kt
@@ -1,3 +1,65 @@
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.serialization.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import org.litote.kmongo.*
+import org.litote.kmongo.async.*
+import org.litote.kmongo.coroutine.*
+import org.litote.kmongo.async.getCollection
+import com.mongodb.ConnectionString
+
+val connectionString: ConnectionString? = System.getenv("MONGODB_URI")?.let {
+    ConnectionString("$it?retryWrites=false")
+}
+
+val client = if (connectionString != null) KMongo.createClient(connectionString) else KMongo.createClient()
+val database = client.getDatabase(connectionString?.database ?: "test")
+val collection = database.getCollection<ShoppingListItem>()
+
 fun main() {
-    println("Hello, JVM!")
+    val port = System.getenv("PORT")?.toInt() ?: 9090
+    embeddedServer(Netty, port) {
+        install(ContentNegotiation) {
+            json()
+        }
+        install(CORS) {
+            method(HttpMethod.Get)
+            method(HttpMethod.Post)
+            method(HttpMethod.Delete)
+            anyHost()
+        }
+        install(Compression) {
+            gzip()
+        }
+
+        routing {
+            get("/") {
+                call.respondText(
+                    this::class.java.classLoader.getResource("index.html")!!.readText(),
+                    ContentType.Text.Html
+                )
+            }
+            static("/") {
+                resources("")
+            }
+            get(ShoppingListItem.path) {
+                call.respond(collection.find().toList())
+            }
+            post(ShoppingListItem.path) {
+                collection.insertOne(call.receive<ShoppingListItem>())
+                call.respond(HttpStatusCode.OK)
+            }
+            delete(ShoppingListItem.path + "/{id}") {
+                val id = call.parameters["id"]?.toInt() ?: error("Invalid delete request")
+                collection.deleteOne(ShoppingListItem::id eq id)
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+    }.start(wait = true)
 }

--- a/src/jvmMain/kotlin/Server.kt
+++ b/src/jvmMain/kotlin/Server.kt
@@ -48,17 +48,19 @@ fun main() {
             static("/") {
                 resources("")
             }
-            get(ShoppingListItem.path) {
-                call.respond(collection.find().toList())
-            }
-            post(ShoppingListItem.path) {
-                collection.insertOne(call.receive<ShoppingListItem>())
-                call.respond(HttpStatusCode.OK)
-            }
-            delete(ShoppingListItem.path + "/{id}") {
-                val id = call.parameters["id"]?.toInt() ?: error("Invalid delete request")
-                collection.deleteOne(ShoppingListItem::id eq id)
-                call.respond(HttpStatusCode.OK)
+            route(ShoppingListItem.path) {
+                get {
+                    call.respond(collection.find().toList())
+                }
+                post {
+                    collection.insertOne(call.receive<ShoppingListItem>())
+                    call.respond(HttpStatusCode.OK)
+                }
+                delete("/{id}") {
+                    val id = call.parameters["id"]?.toInt() ?: error("Invalid delete request")
+                    collection.deleteOne(ShoppingListItem::id eq id)
+                    call.respond(HttpStatusCode.OK)
+                }
             }
         }
     }.start(wait = true)


### PR DESCRIPTION
There's a problem with NodeJs 14.17.0 on computers with MacOS and M1 CPU.
Kotlin with version 1.6.10 downloads this version of node so the application can't be built.
Here's the link to an example discussion: 
https://youtrack.jetbrains.com/issue/KT-49109

Here, you can find the version suggested by Kotlin developers (1.6.21):
https://kotlinlang.org/docs/js-project-setup.html

That's why I have updated the version of Kotlin to 1.6.21.