### PR TITLE
Bump Kotlin version from 1.6.10 to 1.6.21 (master)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ val reactVersion = "17.0.2-pre.299-kotlin-1.6.10"
 val kmongoVersion = "4.5.0"
 
 plugins {
-    kotlin("multiplatform") version "1.6.10"
+    kotlin("multiplatform") version "1.6.21"
     application //to run JVM part
     kotlin("plugin.serialization") version "1.6.10"
 }


### PR DESCRIPTION
There's a problem with NodeJs 14.17.0 on computers with MacOS and M1 CPU.
Kotlin with version 1.6.10 downloads this version of node so the application can't be built.
Here's the link to an example discussion: 
https://youtrack.jetbrains.com/issue/KT-49109

Here, you can find the version suggested by Kotlin developers (1.6.21):
https://kotlinlang.org/docs/js-project-setup.html

That's why I have updated the version of Kotlin to 1.6.21.