### PR TITLE
Fix macOS local build issue related to node js v14 used by default.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,12 @@ repositories {
     mavenCentral()
 }
 
+plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
+    configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
+        nodeVersion = "16.15.1"
+    }
+}
+
 kotlin {
     jvm {
         withJava()


### PR DESCRIPTION
Use latest supported nodejs version (v16.15.1) included darwin-arm64 dist.