### PR TITLE
Remove unnecessary window.location.origin usage.

### DIFF
--- a/src/jsMain/kotlin/Api.kt
+++ b/src/jsMain/kotlin/Api.kt
@@ -7,8 +7,6 @@ import io.ktor.serialization.kotlinx.json.*
 
 import kotlinx.browser.window
 
-val endpoint = window.location.origin // only needed until https://github.com/ktorio/ktor/issues/1695 is resolved
-
 val jsonClient = HttpClient {
     install(ContentNegotiation) {
         json()
@@ -16,16 +14,16 @@ val jsonClient = HttpClient {
 }
 
 suspend fun getShoppingList(): List<ShoppingListItem> {
-    return jsonClient.get(endpoint + ShoppingListItem.path).body()
+    return jsonClient.get(ShoppingListItem.path).body()
 }
 
 suspend fun addShoppingListItem(shoppingListItem: ShoppingListItem) {
-    jsonClient.post(endpoint + ShoppingListItem.path) {
+    jsonClient.post(ShoppingListItem.path) {
         contentType(ContentType.Application.Json)
         setBody(shoppingListItem)
-    }
+  }
 }
 
 suspend fun deleteShoppingListItem(shoppingListItem: ShoppingListItem) {
-    jsonClient.delete(endpoint + ShoppingListItem.path + "/${shoppingListItem.id}")
+    jsonClient.delete(ShoppingListItem.path + "/${shoppingListItem.id}")
 }


### PR DESCRIPTION
https://kotlinlang.org/docs/multiplatform-full-stack-app.html#write-the-api-client can be updated now, too, if I understand right.