### PR TITLE
Fix CORS for PaaS deploy

### DIFF
--- a/src/jvmMain/kotlin/Server.kt
+++ b/src/jvmMain/kotlin/Server.kt
@@ -30,6 +30,7 @@ fun main() {
             json()
         }
         install(CORS) {
+            allowHeader(HttpHeaders.ContentType)
             allowMethod(HttpMethod.Get)
             allowMethod(HttpMethod.Post)
             allowMethod(HttpMethod.Delete)


### PR DESCRIPTION
This string allows you, for example, upload your app to Heroku while you DB is in MongoDB Atlas. In this case CORS blocks your POST requests. See https://youtrack.jetbrains.com/issue/KTOR-4008/POST-request-to-database-returns-403-error#focus=Comments-27-6434385.0-0